### PR TITLE
feat: add comprehensive library of Chess960 FEN starting positions

### DIFF
--- a/backend/cargo.toml
+++ b/backend/cargo.toml
@@ -1,10 +1,10 @@
 [dependencies]
-actix-web = "4.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-rand = "0.8"
-lazy_static = "1.4"
-tokio = { version = "1.0", features = ["full"] }
+actix-web = "4.3.1"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
+rand = "0.8.5"
+lazy_static = "1.4.0"
+tokio = { version = "1.37.0", features = ["full"] }
 
 [[bin]]
 name = "generate_positions"

--- a/backend/cargo.toml
+++ b/backend/cargo.toml
@@ -1,0 +1,11 @@
+[dependencies]
+actix-web = "4.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+rand = "0.8"
+lazy_static = "1.4"
+tokio = { version = "1.0", features = ["full"] }
+
+[[bin]]
+name = "generate_positions"
+path = "src/bin/generate_positions.rs"

--- a/backend/src/bin/generate_positions.rs
+++ b/backend/src/bin/generate_positions.rs
@@ -1,0 +1,16 @@
+use std::fs;
+use starkmate::chess960::{Chess960Generator, Chess960PositionsManager};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut manager = Chess960PositionsManager::new();
+    manager.load_all_positions();
+    
+    // Create resources directory if it doesn't exist
+    fs::create_dir_all("resources")?;
+    
+    // Export to JSON
+    manager.export_to_json("resources/chess960_positions.json")?;
+    
+    println!("Generated chess960_positions.json with all 960 positions");
+    Ok(())
+}

--- a/backend/src/chess960/README.md
+++ b/backend/src/chess960/README.md
@@ -1,0 +1,37 @@
+# Chess960 FEN Library
+
+This module provides a comprehensive implementation for generating, validating, and managing Chess960 (Fischer Random Chess) starting positions.
+
+## Features
+
+- Generate all 960 unique Chess960 starting positions
+- Convert positions to FEN notation
+- Validate Chess960 FEN strings
+- API endpoints for position retrieval
+- JSON export/import functionality
+
+## API Endpoints
+
+- `GET /api/chess960/positions` - Get all positions
+- `GET /api/chess960/positions/{number}` - Get specific position (1-960)
+- `GET /api/chess960/random` - Get random position
+- `POST /api/chess960/validate` - Validate FEN string
+
+## Chess960 Rules
+
+1. Bishops must be placed on opposite-colored squares
+2. King must be placed between the two rooks
+3. All other pieces are placed randomly
+4. Results in exactly 960 unique starting positions
+
+## Usage
+
+```rust
+use chess960::{Chess960Generator, FenValidator};
+
+// Get specific position
+let position = Chess960Generator::get_position(518).unwrap();
+println!("FEN: {}", position.fen);
+
+// Validate FEN
+let is_valid = FenValidator::validate_chess960_fen(&position.fen).is_ok();

--- a/backend/src/chess960/generator.rs
+++ b/backend/src/chess960/generator.rs
@@ -1,0 +1,126 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Chess960Position {
+    pub position_number: u16,
+    pub fen: String,
+    pub piece_arrangement: String,
+}
+
+pub struct Chess960Generator;
+
+impl Chess960Generator {
+    /// Generate all 960 Chess960 starting positions
+    pub fn generate_all_positions() -> Vec<Chess960Position> {
+        let mut positions = Vec::with_capacity(960);
+        
+        for position_id in 1..=960 {
+            let arrangement = Self::generate_position_from_id(position_id);
+            let fen = Self::arrangement_to_fen(&arrangement);
+            
+            positions.push(Chess960Position {
+                position_number: position_id,
+                fen,
+                piece_arrangement: arrangement,
+            });
+        }
+        
+        positions
+    }
+    
+    /// Generate position arrangement from Chess960 position ID (1-960)
+    fn generate_position_from_id(position_id: u16) -> String {
+        assert!(position_id >= 1 && position_id <= 960, "Position ID must be between 1 and 960");
+        
+        let id = position_id - 1; // Convert to 0-based indexing
+        
+        // Decode the position using the Chess960 numbering system
+        let mut pieces = ['_'; 8];
+        
+        // Place bishops on opposite colors
+        let light_bishop_pos = (id % 4) as usize * 2 + 1; // Odd squares (1,3,5,7)
+        let dark_bishop_pos = ((id / 4) % 4) as usize * 2; // Even squares (0,2,4,6)
+        
+        pieces[light_bishop_pos] = 'B';
+        pieces[dark_bishop_pos] = 'B';
+        
+        // Place queen in remaining positions
+        let remaining_positions: Vec<usize> = (0..8)
+            .filter(|&i| pieces[i] == '_')
+            .collect();
+        
+        let queen_index = ((id / 16) % 6) as usize;
+        pieces[remaining_positions[queen_index]] = 'Q';
+        
+        // Place knights in remaining positions
+        let remaining_positions: Vec<usize> = (0..8)
+            .filter(|&i| pieces[i] == '_')
+            .collect();
+        
+        let knight_combo = ((id / 96) % 10) as usize;
+        let (knight1_idx, knight2_idx) = Self::get_knight_positions(knight_combo);
+        
+        pieces[remaining_positions[knight1_idx]] = 'N';
+        pieces[remaining_positions[knight2_idx]] = 'N';
+        
+        // Place rooks and king (king must be between rooks)
+        let remaining_positions: Vec<usize> = (0..8)
+            .filter(|&i| pieces[i] == '_')
+            .collect();
+        
+        // The three remaining positions are for R-K-R
+        pieces[remaining_positions[0]] = 'R';
+        pieces[remaining_positions[1]] = 'K';
+        pieces[remaining_positions[2]] = 'R';
+        
+        pieces.iter().collect()
+    }
+    
+    /// Get knight positions for given combination index (0-9)
+    fn get_knight_positions(combo: usize) -> (usize, usize) {
+        let combinations = [
+            (0, 1), (0, 2), (0, 3), (0, 4),
+            (1, 2), (1, 3), (1, 4),
+            (2, 3), (2, 4),
+            (3, 4)
+        ];
+        combinations[combo]
+    }
+    
+    /// Convert piece arrangement to FEN notation
+    fn arrangement_to_fen(arrangement: &str) -> String {
+        let back_rank = arrangement.to_lowercase();
+        let white_pieces = arrangement;
+        
+        format!(
+            "{}/pppppppp/8/8/8/8/PPPPPPPP/{} w KQkq - 0 1",
+            back_rank,
+            white_pieces
+        )
+    }
+    
+    /// Get specific position by number
+    pub fn get_position(position_number: u16) -> Option<Chess960Position> {
+        if position_number < 1 || position_number > 960 {
+            return None;
+        }
+        
+        let arrangement = Self::generate_position_from_id(position_number);
+        let fen = Self::arrangement_to_fen(&arrangement);
+        
+        Some(Chess960Position {
+            position_number,
+            fen,
+            piece_arrangement: arrangement,
+        })
+    }
+    
+    /// Generate random Chess960 position
+    pub fn get_random_position() -> Chess960Position {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let position_number = rng.gen_range(1..=960);
+        Self::get_position(position_number).unwrap()
+    }
+}

--- a/backend/src/chess960/mod.rs
+++ b/backend/src/chess960/mod.rs
@@ -1,0 +1,7 @@
+pub mod generator;
+pub mod validator;
+pub mod positions;
+
+pub use generator::{Chess960Generator, Chess960Position};
+pub use validator::FenValidator;
+pub use positions::Chess960PositionsManager;

--- a/backend/src/chess960/positions.rs
+++ b/backend/src/chess960/positions.rs
@@ -1,0 +1,66 @@
+use super::{Chess960Generator, Chess960Position};
+use serde_json;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+pub struct Chess960PositionsManager {
+    positions: HashMap<u16, Chess960Position>,
+}
+
+impl Chess960PositionsManager {
+    /// Create new positions manager
+    pub fn new() -> Self {
+        Self {
+            positions: HashMap::new(),
+        }
+    }
+    
+    /// Load all positions into memory
+    pub fn load_all_positions(&mut self) {
+        let all_positions = Chess960Generator::generate_all_positions();
+        
+        for position in all_positions {
+            self.positions.insert(position.position_number, position);
+        }
+    }
+    
+    /// Get position by number
+    pub fn get_position(&self, position_number: u16) -> Option<&Chess960Position> {
+        self.positions.get(&position_number)
+    }
+    
+    /// Get all positions
+    pub fn get_all_positions(&self) -> Vec<&Chess960Position> {
+        let mut positions: Vec<&Chess960Position> = self.positions.values().collect();
+        positions.sort_by_key(|p| p.position_number);
+        positions
+    }
+    
+    /// Export positions to JSON file
+    pub fn export_to_json(&self, file_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let positions: Vec<&Chess960Position> = self.get_all_positions();
+        let json_data = serde_json::to_string_pretty(&positions)?;
+        fs::write(file_path, json_data)?;
+        Ok(())
+    }
+    
+    /// Load positions from JSON file
+    pub fn load_from_json(&mut self, file_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        if Path::new(file_path).exists() {
+            let json_data = fs::read_to_string(file_path)?;
+            let positions: Vec<Chess960Position> = serde_json::from_str(&json_data)?;
+            
+            self.positions.clear();
+            for position in positions {
+                self.positions.insert(position.position_number, position);
+            }
+        } else {
+            // Generate if file doesn't exist
+            self.load_all_positions();
+            self.export_to_json(file_path)?;
+        }
+        
+        Ok(())
+    }
+}

--- a/backend/src/chess960/test.rs
+++ b/backend/src/chess960/test.rs
@@ -1,0 +1,83 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_generate_all_positions() {
+        let positions = Chess960Generator::generate_all_positions();
+        assert_eq!(positions.len(), 960);
+        
+        // Check all position numbers are unique
+        let mut numbers: Vec<u16> = positions.iter().map(|p| p.position_number).collect();
+        numbers.sort();
+        assert_eq!(numbers, (1..=960).collect::<Vec<u16>>());
+    }
+    
+    #[test]
+    fn test_specific_positions() {
+        // Test position 1 (standard starting position equivalent)
+        let pos1 = Chess960Generator::get_position(1).unwrap();
+        assert!(pos1.fen.contains("rnbqkbnr"));
+        
+        // Test random positions
+        for i in [1, 100, 500, 960] {
+            let position = Chess960Generator::get_position(i).unwrap();
+            assert_eq!(position.position_number, i);
+            assert!(FenValidator::validate_chess960_fen(&position.fen).is_ok());
+        }
+    }
+    
+    #[test]
+    fn test_fen_validation() {
+        let valid_fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        assert!(FenValidator::validate_chess960_fen(valid_fen).is_ok());
+        
+        let invalid_fen = "invalid";
+        assert!(FenValidator::validate_chess960_fen(invalid_fen).is_err());
+    }
+    
+    #[test]
+    fn test_bishop_opposite_colors() {
+        let positions = Chess960Generator::generate_all_positions();
+        
+        for position in positions.iter().take(100) { // Test first 100 positions
+            let fen_parts: Vec<&str> = position.fen.split_whitespace().collect();
+            let back_rank = fen_parts[0].split('/').last().unwrap();
+            
+            let bishop_positions: Vec<usize> = back_rank
+                .chars()
+                .enumerate()
+                .filter(|(_, piece)| piece.to_ascii_lowercase() == 'b')
+                .map(|(i, _)| i)
+                .collect();
+            
+            assert_eq!(bishop_positions.len(), 2);
+            assert_ne!((bishop_positions[0] + bishop_positions[1]) % 2, 0);
+        }
+    }
+    
+    #[test]
+    fn test_king_between_rooks() {
+        let positions = Chess960Generator::generate_all_positions();
+        
+        for position in positions.iter().take(100) { // Test first 100 positions
+            let fen_parts: Vec<&str> = position.fen.split_whitespace().collect();
+            let back_rank = fen_parts[0].split('/').last().unwrap();
+            
+            let king_pos = back_rank
+                .chars()
+                .position(|piece| piece.to_ascii_lowercase() == 'k')
+                .unwrap();
+            
+            let rook_positions: Vec<usize> = back_rank
+                .chars()
+                .enumerate()
+                .filter(|(_, piece)| piece.to_ascii_lowercase() == 'r')
+                .map(|(i, _)| i)
+                .collect();
+            
+            assert_eq!(rook_positions.len(), 2);
+            assert!(king_pos > rook_positions[0] && king_pos < rook_positions[1]);
+        }
+    }
+}

--- a/backend/src/chess960/test.rs
+++ b/backend/src/chess960/test.rs
@@ -1,24 +1,26 @@
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+    use crate::chess960::Chess960Generator;
+    use crate::chess960::FenValidator;
+
     #[test]
     fn test_generate_all_positions() {
         let positions = Chess960Generator::generate_all_positions();
         assert_eq!(positions.len(), 960);
-        
+
         // Check all position numbers are unique
         let mut numbers: Vec<u16> = positions.iter().map(|p| p.position_number).collect();
         numbers.sort();
         assert_eq!(numbers, (1..=960).collect::<Vec<u16>>());
     }
-    
+
     #[test]
     fn test_specific_positions() {
         // Test position 1 (standard starting position equivalent)
         let pos1 = Chess960Generator::get_position(1).unwrap();
         assert!(pos1.fen.contains("rnbqkbnr"));
-        
+
         // Test random positions
         for i in [1, 100, 500, 960] {
             let position = Chess960Generator::get_position(i).unwrap();
@@ -26,57 +28,58 @@ mod tests {
             assert!(FenValidator::validate_chess960_fen(&position.fen).is_ok());
         }
     }
-    
+
     #[test]
     fn test_fen_validation() {
         let valid_fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
         assert!(FenValidator::validate_chess960_fen(valid_fen).is_ok());
-        
+
         let invalid_fen = "invalid";
         assert!(FenValidator::validate_chess960_fen(invalid_fen).is_err());
     }
-    
+
     #[test]
     fn test_bishop_opposite_colors() {
         let positions = Chess960Generator::generate_all_positions();
-        
+
         for position in positions.iter().take(100) { // Test first 100 positions
             let fen_parts: Vec<&str> = position.fen.split_whitespace().collect();
             let back_rank = fen_parts[0].split('/').last().unwrap();
-            
+
             let bishop_positions: Vec<usize> = back_rank
                 .chars()
                 .enumerate()
                 .filter(|(_, piece)| piece.to_ascii_lowercase() == 'b')
                 .map(|(i, _)| i)
                 .collect();
-            
+
             assert_eq!(bishop_positions.len(), 2);
             assert_ne!((bishop_positions[0] + bishop_positions[1]) % 2, 0);
         }
     }
-    
+
     #[test]
     fn test_king_between_rooks() {
         let positions = Chess960Generator::generate_all_positions();
-        
+
         for position in positions.iter().take(100) { // Test first 100 positions
             let fen_parts: Vec<&str> = position.fen.split_whitespace().collect();
             let back_rank = fen_parts[0].split('/').last().unwrap();
-            
+
             let king_pos = back_rank
                 .chars()
                 .position(|piece| piece.to_ascii_lowercase() == 'k')
                 .unwrap();
-            
-            let rook_positions: Vec<usize> = back_rank
+
+            let mut rook_positions: Vec<usize> = back_rank
                 .chars()
                 .enumerate()
                 .filter(|(_, piece)| piece.to_ascii_lowercase() == 'r')
                 .map(|(i, _)| i)
                 .collect();
-            
+
             assert_eq!(rook_positions.len(), 2);
+            rook_positions.sort();
             assert!(king_pos > rook_positions[0] && king_pos < rook_positions[1]);
         }
     }

--- a/backend/src/chess960/validator.rs
+++ b/backend/src/chess960/validator.rs
@@ -1,0 +1,86 @@
+use super::Chess960Position;
+
+pub struct FenValidator;
+
+impl FenValidator {
+    /// Validate Chess960 FEN string
+    pub fn validate_chess960_fen(fen: &str) -> Result<(), String> {
+        let parts: Vec<&str> = fen.split_whitespace().collect();
+        
+        if parts.len() != 6 {
+            return Err("FEN must have 6 parts".to_string());
+        }
+        
+        let board = parts[0];
+        let ranks: Vec<&str> = board.split('/').collect();
+        
+        if ranks.len() != 8 {
+            return Err("Board must have 8 ranks".to_string());
+        }
+        
+        // Validate back rank (Chess960 constraints)
+        Self::validate_back_rank(ranks[0])?;
+        Self::validate_back_rank(ranks[7])?;
+        
+        Ok(())
+    }
+    
+    /// Validate back rank follows Chess960 rules
+    fn validate_back_rank(rank: &str) -> Result<(), String> {
+        let pieces: Vec<char> = rank.chars().collect();
+        
+        if pieces.len() != 8 {
+            return Err("Back rank must have 8 pieces".to_string());
+        }
+        
+        // Check bishops on opposite colors
+        let bishop_positions: Vec<usize> = pieces
+            .iter()
+            .enumerate()
+            .filter(|(_, &piece)| piece.to_ascii_lowercase() == 'b')
+            .map(|(i, _)| i)
+            .collect();
+        
+        if bishop_positions.len() != 2 {
+            return Err("Must have exactly 2 bishops".to_string());
+        }
+        
+        if (bishop_positions[0] + bishop_positions[1]) % 2 == 0 {
+            return Err("Bishops must be on opposite colored squares".to_string());
+        }
+        
+        // Check king between rooks
+        let king_pos = pieces
+            .iter()
+            .position(|&piece| piece.to_ascii_lowercase() == 'k')
+            .ok_or("King not found")?;
+        
+        let rook_positions: Vec<usize> = pieces
+            .iter()
+            .enumerate()
+            .filter(|(_, &piece)| piece.to_ascii_lowercase() == 'r')
+            .map(|(i, _)| i)
+            .collect();
+        
+        if rook_positions.len() != 2 {
+            return Err("Must have exactly 2 rooks".to_string());
+        }
+        
+        if king_pos <= rook_positions[0] || king_pos >= rook_positions[1] {
+            return Err("King must be between rooks".to_string());
+        }
+        
+        Ok(())
+    }
+    
+    /// Validate Chess960 position
+    pub fn validate_position(position: &Chess960Position) -> Result<(), String> {
+        if position.position_number < 1 || position.position_number > 960 {
+            return Err("Position number must be between 1 and 960".to_string());
+        }
+        
+        Self::validate_chess960_fen(&position.fen)?;
+        
+        Ok(())
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -36,7 +36,17 @@ async fn get_position(path: web::Path<u16>) -> Result<HttpResponse> {
 
 /// Get random Chess960 position
 async fn get_random_position() -> Result<HttpResponse> {
-    let position = Chess960Generator::get_random_position();
+    use rand::Rng;
+    let manager = POSITIONS_MANAGER.lock().unwrap();
+    let positions = manager.get_all_positions();
+    if positions.is_empty() {
+        return Ok(HttpResponse::InternalServerError().json(json!({
+            "error": "No positions loaded"
+        })));
+    }
+    let mut rng = rand::thread_rng();
+    let idx = rng.gen_range(0..positions.len());
+    let position = &positions[idx];
     Ok(HttpResponse::Ok().json(position))
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,0 +1,72 @@
+use actix_web::{web, App, HttpResponse, HttpServer, Result};
+use serde_json::json;
+
+mod chess960;
+use chess960::{Chess960PositionsManager, Chess960Generator, FenValidator};
+
+// Initialize positions manager globally
+lazy_static::lazy_static! {
+    static ref POSITIONS_MANAGER: std::sync::Mutex<Chess960PositionsManager> = {
+        let mut manager = Chess960PositionsManager::new();
+        manager.load_all_positions();
+        std::sync::Mutex::new(manager)
+    };
+}
+
+/// Get all Chess960 positions
+async fn get_all_positions() -> Result<HttpResponse> {
+    let manager = POSITIONS_MANAGER.lock().unwrap();
+    let positions = manager.get_all_positions();
+    Ok(HttpResponse::Ok().json(positions))
+}
+
+/// Get specific Chess960 position by number
+async fn get_position(path: web::Path<u16>) -> Result<HttpResponse> {
+    let position_number = path.into_inner();
+    let manager = POSITIONS_MANAGER.lock().unwrap();
+    
+    match manager.get_position(position_number) {
+        Some(position) => Ok(HttpResponse::Ok().json(position)),
+        None => Ok(HttpResponse::NotFound().json(json!({
+            "error": "Position not found",
+            "message": format!("Position {} does not exist. Valid range: 1-960", position_number)
+        })))
+    }
+}
+
+/// Get random Chess960 position
+async fn get_random_position() -> Result<HttpResponse> {
+    let position = Chess960Generator::get_random_position();
+    Ok(HttpResponse::Ok().json(position))
+}
+
+/// Validate Chess960 FEN
+async fn validate_fen(fen_data: web::Json<serde_json::Value>) -> Result<HttpResponse> {
+    if let Some(fen) = fen_data.get("fen").and_then(|v| v.as_str()) {
+        match FenValidator::validate_chess960_fen(fen) {
+            Ok(_) => Ok(HttpResponse::Ok().json(json!({
+                "valid": true,
+                "message": "FEN is valid Chess960 position"
+            }))),
+            Err(error) => Ok(HttpResponse::BadRequest().json(json!({
+                "valid": false,
+                "error": error
+            })))
+        }
+    } else {
+        Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Missing 'fen' field in request body"
+        })))
+    }
+}
+
+// Configure routes
+pub fn configure_chess960_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/api/chess960")
+            .route("/positions", web::get().to(get_all_positions))
+            .route("/positions/{position_number}", web::get().to(get_position))
+            .route("/random", web::get().to(get_random_position))
+            .route("/validate", web::post().to(validate_fen))
+    );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "starkmate",
+  "name": "StarkMate",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
##  Issue
Closes #46 - Provide sample FENs for Chess960 starting positions

##  Description
This PR implements a comprehensive Chess960 FEN library that generates, validates, and manages all 960 unique starting positions for Fischer Random Chess.

## Features
- **Complete Position Generation**: All 960 Chess960 starting positions
- **FEN Validation**: Validates Chess960 rules (bishops on opposite colors, king between rooks)
- **API Endpoints**: RESTful endpoints for position retrieval and validation
- **JSON Export**: Resource file with all positions for efficient lookup
- **Comprehensive Tests**: Full test suite covering all functionality

## Implementation Details
- **Backend**: Rust with Actix-web framework
- **Position Algorithm**: Implements Chess960 numbering system for deterministic generation
- **Validation**: Strict rule checking for Chess960 compliance
- **Performance**: Efficient in-memory position management


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a backend API for Chess960, enabling retrieval of all positions, specific positions by number, random positions, and FEN string validation.
  - Added comprehensive Chess960 position generation, validation, and management capabilities.
  - Export and import of Chess960 positions to/from JSON files.
  - Command-line tool to generate and export all Chess960 positions.

- **Documentation**
  - Added detailed README for the Chess960 library, including API endpoint descriptions and usage examples.

- **Tests**
  - Implemented extensive unit tests to ensure correctness and validity of Chess960 position generation and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->