### PR TITLE
fix: implement robust WebSocket heartbeat (ping/pong) mechanism

### DIFF
--- a/backend/modules/api/Cargo.toml
+++ b/backend/modules/api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 dotenv = "0.15.0"
 env_logger = "0.11.8"
+log = "0.4"
 actix-web = "4"
 actix = "0.13"
 actix-web-actors = "4"

--- a/backend/modules/api/src/ws.rs
+++ b/backend/modules/api/src/ws.rs
@@ -100,13 +100,22 @@ pub struct WsSession {
 }
 
 impl WsSession {
-    const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
-    const CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+    /// Server sends a ping every 15 seconds to detect dead connections
+    const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+    /// Terminate connection if no pong received within 25 seconds (15s interval + 10s grace)
+    const CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
 
     fn hb(&self, ctx: &mut ws::WebsocketContext<Self>) {
         ctx.run_interval(Self::HEARTBEAT_INTERVAL, |act, ctx| {
-            if std::time::Instant::now().duration_since(act.hb) > Self::CLIENT_TIMEOUT {
-                ctx.stop(); return;
+            let elapsed = std::time::Instant::now().duration_since(act.hb);
+            if elapsed > Self::CLIENT_TIMEOUT {
+                log::warn!(
+                    "WebSocket timeout for game {}: no pong in {}s, terminating connection",
+                    act.game_id,
+                    elapsed.as_secs()
+                );
+                ctx.stop();
+                return;
             }
             ctx.ping(b"");
         });
@@ -123,6 +132,7 @@ impl Actor for WsSession {
     }
 
     fn stopped(&mut self, ctx: &mut Self::Context) {
+        log::info!("WebSocket disconnected for game: {}", self.game_id);
         let addr = ctx.address().recipient();
         self.lobby.do_send(Disconnect { game_id: self.game_id.clone(), addr });
     }


### PR DESCRIPTION
## Summary

Implements aggressive WebSocket heartbeat to clean up ghost connections (closed laptops, WiFi loss) within ~30 seconds.

Closes #92

## Changes

- **Ping interval**: Reduced from 60s to **15s** (server pings every 15 seconds)
- **Client timeout**: Reduced from 30min to **25s** (15s interval + 10s grace for pong reply)
- **Logging**: Added warn/info logs for timeout events and disconnections
- **Dependency**: Added `log` crate for observability

## Files Changed

- `backend/modules/api/Cargo.toml` - Added `log` dependency
- `backend/modules/api/src/ws.rs` - Updated heartbeat constants and added logging

## Testing

The heartbeat mechanism uses Actix's built-in `ws::Message::Ping` and `ws::Message::Pong` handling. When the server sends a ping, compliant WebSocket clients automatically respond with a pong. If no pong is received within the timeout window, the connection is terminated.

This ensures the "Online Players" count remains accurate within ±30 seconds as specified in the requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened WebSocket connection stability through more frequent heartbeat monitoring and reduced timeout detection windows, enabling faster identification of disconnected clients and improving system responsiveness.
  * Enhanced system logging for WebSocket session lifecycle events and timeout scenarios, providing better operational visibility for monitoring and troubleshooting connection-related issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->