### PR TITLE
Fix - Database schema mismatch between migration and entity

### DIFF
--- a/backend/modules/db/migrations/src/m20250604_160341_create_games_and_moves.rs
+++ b/backend/modules/db/migrations/src/m20250604_160341_create_games_and_moves.rs
@@ -1,4 +1,4 @@
-use sea_orm_migration::{prelude::*, schema::*, prelude::extension::postgres::Type};
+use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -6,36 +6,148 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        // Replace the sample below with your own migration scripts
-        todo!();
+        // 1. Add created_at and updated_at columns to the existing game table in smdb schema
+        manager
+            .alter_table(
+                Table::alter()
+                    .table((Smdb, Game::Table))
+                    .add_column(
+                        ColumnDef::new(Game::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .add_column(
+                        ColumnDef::new(Game::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
 
+        // 2. Create the game_moves table in the smdb schema
         manager
             .create_table(
                 Table::create()
-                    .table(Post::Table)
+                    .table((Smdb, GameMove::Table))
                     .if_not_exists()
-                    .col(pk_auto(Post::Id))
-                    .col(string(Post::Title))
-                    .col(string(Post::Text))
+                    .col(
+                        ColumnDef::new(GameMove::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(GameMove::GameId).uuid().not_null())
+                    .col(ColumnDef::new(GameMove::MoveNumber).integer().not_null())
+                    .col(ColumnDef::new(GameMove::San).string().not_null())
+                    .col(ColumnDef::new(GameMove::Fen).string().not_null())
+                    .col(
+                        ColumnDef::new(GameMove::Timestamp)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_game_move_game_id")
+                            .from(GameMove::Table, GameMove::GameId)
+                            .to(Game::Table, Game::Id)
+                            .on_delete(ForeignKeyAction::Cascade)
+                            .on_update(ForeignKeyAction::Cascade),
+                    )
                     .to_owned(),
             )
-            .await
+            .await?;
+
+        // 3. Create indexes on game_moves
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_game_moves_game_id")
+                    .table((Smdb, GameMove::Table))
+                    .col(GameMove::GameId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_game_moves_game_id_move_number")
+                    .table((Smdb, GameMove::Table))
+                    .col(GameMove::GameId)
+                    .col(GameMove::MoveNumber)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        println!("Added created_at/updated_at to game table and created game_moves table.");
+        Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        // Replace the sample below with your own migration scripts
-        todo!();
+        // 1. Drop indexes on game_moves
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_game_moves_game_id_move_number")
+                    .table((Smdb, GameMove::Table))
+                    .to_owned(),
+            )
+            .await?;
 
         manager
-            .drop_table(Table::drop().table(Post::Table).to_owned())
-            .await
+            .drop_index(
+                Index::drop()
+                    .name("idx_game_moves_game_id")
+                    .table((Smdb, GameMove::Table))
+                    .to_owned(),
+            )
+            .await?;
+
+        // 2. Drop game_moves table
+        manager
+            .drop_table(Table::drop().table((Smdb, GameMove::Table)).to_owned())
+            .await?;
+
+        // 3. Remove created_at and updated_at from game table
+        manager
+            .alter_table(
+                Table::alter()
+                    .table((Smdb, Game::Table))
+                    .drop_column(Game::CreatedAt)
+                    .drop_column(Game::UpdatedAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        println!("Dropped game_moves table and removed created_at/updated_at from game table.");
+        Ok(())
     }
 }
 
 #[derive(DeriveIden)]
-enum Post {
+enum Game {
     Table,
     Id,
-    Title,
-    Text,
+    CreatedAt,
+    UpdatedAt,
 }
+
+#[derive(DeriveIden)]
+enum GameMove {
+    Table,
+    Id,
+    GameId,
+    MoveNumber,
+    San,
+    Fen,
+    Timestamp,
+}
+
+#[derive(DeriveIden)]
+struct Smdb;


### PR DESCRIPTION
This pr closes #130 

The migration `m20250604_160341_create_games_and_moves.rs` contained boilerplate `todo!()` code with a sample `Post` table, making it non-functional. Any query against the `game` or `game_move` entity would fail at runtime due to missing columns and tables.

**Changes:**

- Added `created_at` and `updated_at` (timestamptz, non-null, default `now()`) to the existing `smdb.game` table to match `entity/game.rs`
- Created the `smdb.game_moves` table with all columns expected by `entity/game_move.rs` (id, game_id, move_number, san, fen, timestamp)
- Added a foreign key from `game_moves.game_id` to `game.id` with cascade delete/update
- Added indexes: one on `game_id` and a unique composite on `(game_id, move_number)`
- Implemented a proper `down` method that fully reverses the migration


**No other files were modified.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend support for storing games and tracking individual game moves with timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->