### PR TITLE
feat: implement online matchmaking flow with API + WebSocket (#132)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ChessboardComponent from "@/components/chess/ChessboardComponent";
 import { Chess } from "chess.js";
 import GameModeButtons from "@/components/GameModeButtons";
+import { useMatchmaking } from "@/hook/useMatchmaking";
 import { FaUser } from "react-icons/fa";
 import { RiAliensFill } from "react-icons/ri";
 
@@ -12,6 +13,45 @@ export default function Home() {
   const [position, setPosition] = useState("start");
   const [gameMode, setGameMode] = useState<"online" | "bot" | null>(null);
 
+  const {
+    status,
+    playerColor,
+    error: matchmakingError,
+    joinMatchmaking,
+    cancelMatchmaking,
+    sendMove,
+    lastOpponentMove,
+  } = useMatchmaking();
+
+  // Kick off matchmaking when online mode is selected
+  useEffect(() => {
+    if (gameMode === "online") {
+      joinMatchmaking();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameMode]);
+
+  // Apply opponent's move to local chess state
+  useEffect(() => {
+    if (!lastOpponentMove) return;
+    try {
+      const move = game.move({
+        from: lastOpponentMove.from,
+        to: lastOpponentMove.to,
+        promotion: lastOpponentMove.promotion ?? "q",
+      });
+      if (move) setPosition(game.fen());
+    } catch {
+      // illegal move from server — ignore
+    }
+  }, [lastOpponentMove, game]);
+
+  const isMyTurn =
+    gameMode !== "online" ||
+    (status === "connected" &&
+      ((playerColor === "white" && game.turn() === "w") ||
+        (playerColor === "black" && game.turn() === "b")));
+
   const handleMove = ({
     sourceSquare,
     targetSquare,
@@ -19,21 +59,47 @@ export default function Home() {
     sourceSquare: string;
     targetSquare: string;
   }) => {
+    if (!isMyTurn) return false;
+
     try {
       const move = game.move({
         from: sourceSquare,
         to: targetSquare,
         promotion: "q",
       });
-
       if (move === null) return false;
-      requestAnimationFrame(() => {
-        setPosition(game.fen());
-      });
+
+      requestAnimationFrame(() => setPosition(game.fen()));
+
+      // Forward move to server in online mode
+      if (gameMode === "online") {
+        sendMove(sourceSquare, targetSquare, "q");
+      }
+
       return true;
     } catch {
       return false;
     }
+  };
+
+  const handleExit = () => {
+    if (gameMode === "online") cancelMatchmaking();
+    game.reset();
+    setPosition("start");
+    setGameMode(null);
+  };
+
+  const handleSetGameMode = (mode: "online" | "bot" | null) => {
+    setGameMode(mode);
+  };
+
+  // Searching / waiting overlay label
+  const onlineStatusLabel = () => {
+    if (status === "searching") return "🔍 Searching for opponent…";
+    if (status === "match_found") return "✅ Match found! Starting…";
+    if (status === "connected") return `🟢 Online Match (you are ${playerColor})`;
+    if (status === "error") return `❌ ${matchmakingError ?? "Connection error"}`;
+    return "Online Match";
   };
 
   return (
@@ -45,6 +111,7 @@ export default function Home() {
             <div className="w-full min-w-[320px]">
               <ChessboardComponent position={position} onDrop={handleMove} />
             </div>
+
             {gameMode && (
               <div className="mt-4 flex items-center justify-between bg-gradient-to-r from-gray-800/50 to-gray-900/50 p-4 rounded-xl border border-teal-500/20">
                 <div className="flex items-center gap-4">
@@ -56,15 +123,14 @@ export default function Home() {
                     )}
                   </div>
                   <h2 className="text-xl font-bold text-white tracking-wide">
-                    {gameMode === "online" ? "Online Match" : "Playing vs Bot"}
+                    {gameMode === "online"
+                      ? onlineStatusLabel()
+                      : "Playing vs Bot"}
                   </h2>
                 </div>
+
                 <button
-                  onClick={() => {
-                    game.reset();
-                    setPosition("start");
-                    setGameMode(null);
-                  }}
+                  onClick={handleExit}
                   className="px-4 py-2 bg-gradient-to-r from-red-500/20 to-red-600/20 hover:from-red-500/30 hover:to-red-600/30 
                   border border-red-500/30 hover:border-red-400/50 rounded-lg text-white font-medium transition-all duration-300 
                   flex items-center gap-2 group hover:scale-105 active:scale-95"
@@ -87,11 +153,19 @@ export default function Home() {
                 </button>
               </div>
             )}
+
+            {/* Searching spinner */}
+            {gameMode === "online" && status === "searching" && (
+              <div className="mt-3 flex items-center gap-2 text-teal-400 text-sm animate-pulse px-1">
+                <div className="w-3 h-3 rounded-full border-2 border-teal-400 border-t-transparent animate-spin" />
+                Waiting for an opponent to join…
+              </div>
+            )}
           </div>
 
           {/* Game Modes Section */}
           <div className="flex flex-col justify-center space-y-6 max-w-[500px] w-full order-1 md:order-2">
-            {!gameMode && <GameModeButtons setGameMode={setGameMode} />}
+            {!gameMode && <GameModeButtons setGameMode={handleSetGameMode} />}
           </div>
         </div>
       </div>

--- a/frontend/hook/useMatchmaking.ts
+++ b/frontend/hook/useMatchmaking.ts
@@ -1,0 +1,186 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+
+export type MatchmakingStatus =
+  | "idle"
+  | "searching"
+  | "match_found"
+  | "connected"
+  | "error";
+
+interface MatchFoundPayload {
+  gameId: string;
+  color: "white" | "black";
+  opponentId: string;
+}
+
+interface UseMatchmakingReturn {
+  status: MatchmakingStatus;
+  gameId: string | null;
+  playerColor: "white" | "black" | null;
+  error: string | null;
+  joinMatchmaking: () => void;
+  cancelMatchmaking: () => void;
+  sendMove: (from: string, to: string, promotion?: string) => void;
+  lastOpponentMove: { from: string; to: string; promotion?: string } | null;
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const WS_BASE = API_BASE.replace(/^http/, "ws");
+
+export function useMatchmaking(): UseMatchmakingReturn {
+  const [status, setStatus] = useState<MatchmakingStatus>("idle");
+  const [gameId, setGameId] = useState<string | null>(null);
+  const [playerColor, setPlayerColor] = useState<"white" | "black" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastOpponentMove, setLastOpponentMove] = useState<{
+    from: string;
+    to: string;
+    promotion?: string;
+  } | null>(null);
+
+  const matchmakingWsRef = useRef<WebSocket | null>(null);
+  const gameWsRef = useRef<WebSocket | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (matchmakingWsRef.current) {
+      matchmakingWsRef.current.close();
+      matchmakingWsRef.current = null;
+    }
+    if (gameWsRef.current) {
+      gameWsRef.current.close();
+      gameWsRef.current = null;
+    }
+  }, []);
+
+  const openGameSocket = useCallback((gId: string) => {
+    const ws = new WebSocket(`${WS_BASE}/v1/games/${gId}/ws`);
+    gameWsRef.current = ws;
+
+    ws.onopen = () => setStatus("connected");
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "move") {
+          setLastOpponentMove({
+            from: data.from,
+            to: data.to,
+            promotion: data.promotion,
+          });
+        }
+      } catch {
+        // ignore malformed messages
+      }
+    };
+
+    ws.onerror = () => {
+      setError("Game connection error.");
+      setStatus("error");
+    };
+
+    ws.onclose = () => {
+      if (status === "connected") setStatus("idle");
+    };
+  }, [status]);
+
+  const joinMatchmaking = useCallback(async () => {
+    setStatus("searching");
+    setError(null);
+
+    try {
+      // POST to join matchmaking queue, receive a session token
+      const res = await fetch(`${API_BASE}/v1/matchmaking/join`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+      });
+
+      if (!res.ok) throw new Error(`Matchmaking failed: ${res.status}`);
+
+      const { sessionId } = await res.json();
+      sessionIdRef.current = sessionId;
+
+      // Open WebSocket to listen for match_found event
+      const ws = new WebSocket(
+        `${WS_BASE}/v1/matchmaking/ws?session=${sessionId}`
+      );
+      matchmakingWsRef.current = ws;
+
+      ws.onmessage = (event) => {
+        try {
+          const data: { type: string } & Partial<MatchFoundPayload> =
+            JSON.parse(event.data);
+
+          if (data.type === "match_found" && data.gameId && data.color) {
+            setGameId(data.gameId);
+            setPlayerColor(data.color);
+            setStatus("match_found");
+            ws.close();
+            matchmakingWsRef.current = null;
+            openGameSocket(data.gameId);
+          }
+        } catch {
+          // ignore malformed messages
+        }
+      };
+
+      ws.onerror = () => {
+        setError("Matchmaking connection error.");
+        setStatus("error");
+      };
+
+      ws.onclose = () => {
+        if (status === "searching") {
+          // closed without match — either cancelled or error
+        }
+      };
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setStatus("error");
+    }
+  }, [openGameSocket, status]);
+
+  const cancelMatchmaking = useCallback(async () => {
+    cleanup();
+    if (sessionIdRef.current) {
+      // Best-effort cancel; ignore errors
+      fetch(`${API_BASE}/v1/matchmaking/leave`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: sessionIdRef.current }),
+        credentials: "include",
+      }).catch(() => {});
+      sessionIdRef.current = null;
+    }
+    setStatus("idle");
+    setGameId(null);
+    setPlayerColor(null);
+    setError(null);
+  }, [cleanup]);
+
+  const sendMove = useCallback(
+    (from: string, to: string, promotion = "q") => {
+      if (gameWsRef.current?.readyState === WebSocket.OPEN && gameId) {
+        gameWsRef.current.send(
+          JSON.stringify({ type: "move", gameId, from, to, promotion })
+        );
+      }
+    },
+    [gameId]
+  );
+
+  // Cleanup on unmount
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  return {
+    status,
+    gameId,
+    playerColor,
+    error,
+    joinMatchmaking,
+    cancelMatchmaking,
+    sendMove,
+    lastOpponentMove,
+  };
+}


### PR DESCRIPTION
## Overview
Implements online matchmaking flow for Play Online mode.

## Changes
- POST request to /v1/matchmaking/join when user selects Play Online
- Added polling/WebSocket subscription for match_found event
- Opens game WebSocket for real-time moves
- Integrated flow with existing chess UI

## Result
Play Online now connects to backend matchmaking and creates real online games instead of local-only state.

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added online multiplayer mode to queue and play against real opponents.
  * Implemented real-time move synchronization between players during online games.
  * Display live matchmaking status and waiting indicator while searching for opponents.
  * Added turn validation to enforce proper move order in online matches.
  * Graceful exit option to cancel matchmaking and return to game mode selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->