### PR TITLE
Feature/wrap jwt auth middleware

### DIFF
--- a/backend/modules/api/src/server.rs
+++ b/backend/modules/api/src/server.rs
@@ -6,6 +6,7 @@ use dotenv::dotenv;
 use sea_orm::{Database, DatabaseConnection};
 use std::env;
 use security::JwtService;
+use security::JwtAuthMiddleware;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 use utoipa_redoc::{Redoc, Servable};


### PR DESCRIPTION
This PR addresses [Issue #135](https://github.com/NOVUS-X/XLMate/issues/135) by ensuring that the `JwtAuthMiddleware` is applied to the following route scopes in server.rs:
- `/v1/players`
- `/v1/games`
- `/v1/ai`

#### Changes Made:
1. Added `JwtAuthMiddleware` to enforce authentication on the above route scopes.
2. Fixed missing import for `JwtAuthMiddleware` in server.rs.
3. Addressed compilation errors related to middleware wrapping.

#### Why:
Without this middleware, the routes for players, games, and AI endpoints would remain publicly accessible, which is a security risk. This change ensures that only authenticated requests can access these endpoints.

---

### Acceptance Criteria:
- [x] `JwtAuthMiddleware` is correctly applied to the specified routes.
- [x] Code compiles successfully.
- [x] No public access to protected routes without authentication.

---

### Notes:
- Warnings related to unused imports and variables still exist but do not affect functionality.
- Build errors related to `Unpin` for `Governor` middleware were resolved.

---

### Testing:
- Ensure all routes under `/v1/players`, `/v1/games`, and `/v1/ai` require valid JWT tokens.
- Verify no regressions in other parts of the API.

---

closes #135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled JWT authentication on players, games, and AI API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->