### PR TITLE
Add Redis Pub/Sub for cross-node WebSocket scaling

### DIFF
--- a/backend/modules/api/Cargo.toml
+++ b/backend/modules/api/Cargo.toml
@@ -35,6 +35,9 @@ indexmap = "=2.2.6"
 db_entity = { path = "../db/entity" }
 actix-governor = "0.5"
 
+# For Redis Pub/Sub in WebSocket
+redis = { version = "0.24", features = ["tokio-comp", "json"] }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 actix-rt = "2.9"

--- a/backend/modules/api/src/ws.rs
+++ b/backend/modules/api/src/ws.rs
@@ -9,6 +9,12 @@ use jsonwebtoken::{decode, DecodingKey, Validation, Algorithm};
 use actix_web::error::ErrorUnauthorized;
 use serde_json::{Value, json};
 
+// For Redis Pub/Sub
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+use tokio::task::JoinHandle;
+use std::sync::Arc;
+
 /// Core WebSocket message types
 #[derive(Message, Serialize, Clone, Debug, PartialEq)]
 #[rtype(result = "()")]
@@ -96,6 +102,8 @@ impl Handler<Broadcast> for LobbyState {
 pub struct WsSession {
     pub game_id: String,
     pub lobby: Addr<LobbyState>,
+    pub redis_conn: Option<Arc<ConnectionManager>>, // Redis connection for Pub/Sub
+    pub redis_sub_task: Option<JoinHandle<()>>,     // Handle for the subscription task
     hb: std::time::Instant,
 }
 
@@ -129,12 +137,39 @@ impl Actor for WsSession {
         self.hb(ctx);
         let addr = ctx.address().recipient();
         self.lobby.do_send(Connect { game_id: self.game_id.clone(), addr });
+
+        // If Redis connection is available, subscribe to match channel
+        if let Some(redis_conn) = self.redis_conn.clone() {
+            let game_id = self.game_id.clone();
+            let addr = ctx.address();
+            let channel = format!("match:{}", game_id);
+            // Spawn a background task for Redis subscription
+            let handle = tokio::spawn(async move {
+                let mut pubsub = redis_conn.clone().into_pubsub();
+                if pubsub.subscribe(&channel).await.is_ok() {
+                    let mut stream = pubsub.on_message();
+                    while let Some(msg) = stream.next().await {
+                        if let Ok(payload): Result<String, _> = msg.get_payload() {
+                            // Forward to session actor
+                            if let Ok(ws_msg) = serde_json::from_str::<WsMessage>(&payload) {
+                                let _ = addr.do_send(ws_msg);
+                            }
+                        }
+                    }
+                }
+            });
+            self.redis_sub_task = Some(handle);
+        }
     }
 
     fn stopped(&mut self, ctx: &mut Self::Context) {
         log::info!("WebSocket disconnected for game: {}", self.game_id);
         let addr = ctx.address().recipient();
         self.lobby.do_send(Disconnect { game_id: self.game_id.clone(), addr });
+        // Cancel Redis subscription task if running
+        if let Some(handle) = self.redis_sub_task.take() {
+            handle.abort();
+        }
     }
 }
 
@@ -148,7 +183,22 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsSession {
             Ok(ws::Message::Pong(_)) => {
                 self.hb = std::time::Instant::now();
             }
-            Ok(ws::Message::Text(_)) | Ok(ws::Message::Binary(_)) => {}
+            Ok(ws::Message::Text(text)) => {
+                // Try to parse as WsMessage
+                if let Ok(ws_msg) = serde_json::from_str::<WsMessage>(&text) {
+                    // Publish to Redis if connection available
+                    if let Some(redis_conn) = self.redis_conn.clone() {
+                        let channel = format!("match:{}", self.game_id);
+                        let payload = text.clone();
+                        // Spawn a task to publish (non-blocking)
+                        tokio::spawn(async move {
+                            let mut conn = (*redis_conn).clone();
+                            let _: redis::RedisResult<()> = conn.publish(channel, payload).await;
+                        });
+                    }
+                }
+            }
+            Ok(ws::Message::Binary(_)) => {}
             Ok(ws::Message::Close(reason)) => {
                 ctx.close(reason);
                 ctx.stop();


### PR DESCRIPTION
This pull request adds Redis Pub/Sub integration to the WebSocket (`WsSession`) implementation, enabling real-time message broadcasting across distributed server instances. The changes introduce asynchronous Redis communication for both publishing and subscribing to game-specific channels, ensuring that WebSocket messages are synchronized even when sessions are handled by different server processes.

**Redis Pub/Sub integration for WebSocket sessions:**

* Added the `redis` crate (with `tokio-comp` and `json` features) as a dependency in `Cargo.toml` to support asynchronous Redis operations.
* Updated the `WsSession` struct to include optional fields for a Redis connection manager and a background subscription task handle, enabling each session to interact with Redis Pub/Sub.
* On session start, if a Redis connection is present, the actor spawns a background task to subscribe to a game-specific Redis channel. Incoming messages are forwarded to the session actor, allowing cross-process message delivery. The subscription task is properly aborted when the session stops.
* Modified the WebSocket message handler to publish incoming `Text` messages to the corresponding Redis channel if a connection is available, ensuring outgoing messages are broadcast to all subscribers.

**Supporting code changes:**

* Imported necessary types and modules for asynchronous Redis commands, connection management, and background task handling in `ws.rs`.

close #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket sessions now support Redis Pub/Sub integration, enabling real-time message publishing and subscription to game-specific channels for improved synchronization across multiple connected clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->