### PR TITLE
Implement WebSocket reconnect logic in useChessSocket hook

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import dynamic from "next/dynamic";
 const ChessboardComponent = dynamic(() => import("@/components/chess/ChessboardComponent"), { ssr: false });
 import { Chess } from "chess.js";
 const GameModeButtons = dynamic(() => import("@/components/GameModeButtons"), { ssr: false });
 import { FaUser } from "react-icons/fa";
 import { RiAliensFill } from "react-icons/ri";
+import { useChessSocket } from "@/hook/useChessSocket";
+import { useMatchmaking } from "@/hook/useMatchmaking";
 
 export default function Home() {
   const [game] = useState(new Chess());
@@ -14,14 +16,31 @@ export default function Home() {
   const [gameMode, setGameMode] = useState<"online" | "bot" | null>(null);
 
   const {
-    status,
+    status: matchmakingStatus,
     playerColor,
     error: matchmakingError,
     joinMatchmaking,
     cancelMatchmaking,
-    sendMove,
+    sendMove: matchmakingSendMove,
     lastOpponentMove,
+    gameId,
   } = useMatchmaking();
+
+  const {
+    status: socketStatus,
+    sendMove: socketSendMove,
+    disconnect: disconnectSocket,
+    reconnect: reconnectSocket,
+  } = useChessSocket(gameId);
+
+  // Choose which sendMove to use based on game state
+  const sendMove = useCallback((from: string, to: string, promotion?: string) => {
+    if (gameId) {
+      socketSendMove({ from, to, promotion: promotion || "q" });
+    } else {
+      matchmakingSendMove(from, to, promotion);
+    }
+  }, [gameId, socketSendMove, matchmakingSendMove]);
 
   // Kick off matchmaking when online mode is selected
   useEffect(() => {
@@ -48,7 +67,7 @@ export default function Home() {
 
   const isMyTurn =
     gameMode !== "online" ||
-    (status === "connected" &&
+    (socketStatus === "connected" &&
       ((playerColor === "white" && game.turn() === "w") ||
         (playerColor === "black" && game.turn() === "b")));
 
@@ -83,7 +102,10 @@ export default function Home() {
   };
 
   const handleExit = () => {
-    if (gameMode === "online") cancelMatchmaking();
+    if (gameMode === "online") {
+      cancelMatchmaking();
+      disconnectSocket();
+    }
     game.reset();
     setPosition("start");
     setGameMode(null);
@@ -95,10 +117,11 @@ export default function Home() {
 
   // Searching / waiting overlay label
   const onlineStatusLabel = () => {
-    if (status === "searching") return "🔍 Searching for opponent…";
-    if (status === "match_found") return "✅ Match found! Starting…";
-    if (status === "connected") return `🟢 Online Match (you are ${playerColor})`;
-    if (status === "error") return `❌ ${matchmakingError ?? "Connection error"}`;
+    if (socketStatus === "reconnecting") return "🔄 Reconnecting...";
+    if (matchmakingStatus === "searching") return "🔍 Searching for opponent…";
+    if (matchmakingStatus === "match_found") return "✅ Match found! Starting…";
+    if (socketStatus === "connected") return `🟢 Online Match (you are ${playerColor})`;
+    if (matchmakingStatus === "error" || socketStatus === "error") return `❌ ${matchmakingError ?? "Connection error"}`;
     return "Online Match";
   };
 
@@ -155,10 +178,29 @@ export default function Home() {
             )}
 
             {/* Searching spinner */}
-            {gameMode === "online" && status === "searching" && (
+            {gameMode === "online" && matchmakingStatus === "searching" && (
               <div className="mt-3 flex items-center gap-2 text-teal-400 text-sm animate-pulse px-1">
                 <div className="w-3 h-3 rounded-full border-2 border-teal-400 border-t-transparent animate-spin" />
                 Waiting for an opponent to join…
+              </div>
+            )}
+
+            {/* Reconnection overlay */}
+            {gameMode === "online" && socketStatus === "reconnecting" && (
+              <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center">
+                <div className="bg-gray-800 p-6 rounded-xl border border-yellow-500/30 text-center">
+                  <div className="flex flex-col items-center gap-4">
+                    <div className="w-8 h-8 rounded-full border-2 border-yellow-500 border-t-transparent animate-spin" />
+                    <h3 className="text-xl font-bold text-yellow-400">Reconnecting...</h3>
+                    <p className="text-gray-300 text-sm">Attempting to restore connection</p>
+                    <button
+                      onClick={reconnectSocket}
+                      className="mt-2 px-4 py-2 bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/50 rounded-lg text-yellow-400 font-medium transition-all duration-300"
+                    >
+                      Reconnect Now
+                    </button>
+                  </div>
+                </div>
               </div>
             )}
           </div>

--- a/frontend/hook/useChessSocket.ts
+++ b/frontend/hook/useChessSocket.ts
@@ -1,0 +1,228 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+
+export type ChessSocketStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected"
+  | "error";
+
+interface ChessMove {
+  from: string;
+  to: string;
+  promotion?: string;
+}
+
+interface UseChessSocketReturn {
+  status: ChessSocketStatus;
+  gameId: string | null;
+  lastOpponentMove: ChessMove | null;
+  sendMove: (move: ChessMove) => void;
+  disconnect: () => void;
+  reconnect: () => void;
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const WS_BASE = API_BASE.replace(/^http/, "ws");
+
+// Exponential backoff configuration
+const MAX_RECONNECT_ATTEMPTS = 10;
+const INITIAL_RECONNECT_DELAY = 1000; // 1 second
+const MAX_RECONNECT_DELAY = 30000; // 30 seconds
+
+export function useChessSocket(gameId: string | null): UseChessSocketReturn {
+  const [status, setStatus] = useState<ChessSocketStatus>("idle");
+  const [lastOpponentMove, setLastOpponentMove] = useState<ChessMove | null>(null);
+  
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const moveQueueRef = useRef<ChessMove[]>([]);
+  const isManualDisconnectRef = useRef(false);
+
+  const clearReconnectTimeout = useCallback(() => {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+  }, []);
+
+  const calculateReconnectDelay = useCallback((attempt: number): number => {
+    const delay = INITIAL_RECONNECT_DELAY * Math.pow(2, attempt);
+    return Math.min(delay, MAX_RECONNECT_DELAY);
+  }, []);
+
+  const createWebSocket = useCallback((attemptReconnect = false): WebSocket | null => {
+    if (!gameId) return null;
+
+    try {
+      const ws = new WebSocket(`${WS_BASE}/v1/games/${gameId}/ws`);
+      wsRef.current = ws;
+
+      if (attemptReconnect) {
+        setStatus("reconnecting");
+      } else {
+        setStatus("connecting");
+      }
+
+      ws.onopen = () => {
+        console.log(`WebSocket ${attemptReconnect ? 'reconnected' : 'connected'} for game ${gameId}`);
+        setStatus("connected");
+        reconnectAttemptsRef.current = 0;
+        
+        // Send queued moves immediately upon reconnection
+        if (moveQueueRef.current.length > 0) {
+          console.log(`Dispatching ${moveQueueRef.current.length} queued moves`);
+          moveQueueRef.current.forEach(move => {
+            ws.send(JSON.stringify({ 
+              type: "move", 
+              gameId, 
+              from: move.from, 
+              to: move.to, 
+              promotion: move.promotion 
+            }));
+          });
+          moveQueueRef.current = [];
+        }
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === "move") {
+            setLastOpponentMove({
+              from: data.from,
+              to: data.to,
+              promotion: data.promotion,
+            });
+          }
+        } catch (error) {
+          console.error("Failed to parse WebSocket message:", error);
+        }
+      };
+
+      ws.onerror = (error) => {
+        console.error("WebSocket error:", error);
+        setStatus("error");
+      };
+
+      ws.onclose = (event) => {
+        console.log(`WebSocket closed for game ${gameId}. Code: ${event.code}, Reason: ${event.reason}`);
+        
+        if (!isManualDisconnectRef.current) {
+          setStatus("disconnected");
+          // Inline reconnection logic to avoid circular dependency
+          if (reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+            const delay = calculateReconnectDelay(reconnectAttemptsRef.current);
+            console.log(`Attempting reconnection ${reconnectAttemptsRef.current + 1}/${MAX_RECONNECT_ATTEMPTS} in ${delay}ms`);
+            
+            reconnectTimeoutRef.current = setTimeout(() => {
+              reconnectAttemptsRef.current++;
+              createWebSocket(true);
+            }, delay);
+          } else {
+            console.log("Max reconnection attempts reached");
+            setStatus("error");
+          }
+        } else {
+          setStatus("idle");
+          isManualDisconnectRef.current = false;
+        }
+      };
+
+      return ws;
+    } catch (error) {
+      console.error("Failed to create WebSocket:", error);
+      setStatus("error");
+      return null;
+    }
+  }, [gameId, calculateReconnectDelay]);
+
+  const sendMove = useCallback((move: ChessMove) => {
+    // If WebSocket is open, send immediately
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ 
+        type: "move", 
+        gameId, 
+        from: move.from, 
+        to: move.to, 
+        promotion: move.promotion 
+      }));
+      console.log("Move sent immediately:", move);
+    } else {
+      // Queue the move for when we reconnect
+      moveQueueRef.current.push(move);
+      console.log("Move queued (disconnected):", move);
+      
+      // Start reconnection if not already attempting
+      if (status === "disconnected" || status === "idle") {
+        reconnectAttemptsRef.current = 0;
+        createWebSocket(true);
+      }
+    }
+  }, [gameId, status, createWebSocket]);
+
+  const disconnect = useCallback(() => {
+    isManualDisconnectRef.current = true;
+    clearReconnectTimeout();
+    
+    if (wsRef.current) {
+      wsRef.current.close(1000, "Manual disconnect");
+      wsRef.current = null;
+    }
+    
+    // Clear move queue on manual disconnect
+    moveQueueRef.current = [];
+    reconnectAttemptsRef.current = 0;
+  }, [clearReconnectTimeout]);
+
+  const reconnect = useCallback(() => {
+    isManualDisconnectRef.current = false;
+    clearReconnectTimeout();
+    
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    
+    reconnectAttemptsRef.current = 0;
+    createWebSocket(true);
+  }, [clearReconnectTimeout, createWebSocket]);
+
+  // Initialize WebSocket when gameId changes
+  useEffect(() => {
+    if (gameId) {
+      const ws = createWebSocket();
+      return () => {
+        isManualDisconnectRef.current = true;
+        clearReconnectTimeout();
+        if (ws) {
+          ws.close();
+        }
+      };
+    } else {
+      setStatus("idle");
+      setLastOpponentMove(null);
+    }
+  }, [gameId, createWebSocket, clearReconnectTimeout]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      clearReconnectTimeout();
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, [clearReconnectTimeout]);
+
+  return {
+    status,
+    gameId,
+    lastOpponentMove,
+    sendMove,
+    disconnect,
+    reconnect,
+  };
+}


### PR DESCRIPTION
Description: If the player's internet drops, the WebSocket must queue outgoing moves and seamlessly reconnect when online.
Implementation Guidelines:

Update frontend/hook/useChessSocket.ts.
Implement exponential backoff for reconnection attempts. Dispatch a "RECONNECTING" event to show a UI overlay.
Acceptance Criteria:
Turning off internet simulates a disconnect; turning it back on resyncs board state within 3 seconds.
Queued moves are dispatched immediately upon reconnection.

closes #149 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket-based chess communication with automatic reconnection support.
  * Integrated separate socket connection for real-time game moves.
  * Added "Reconnecting..." overlay with manual reconnect button.
  * Enhanced game status display to include connection states (connecting, reconnecting, disconnected, error).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->