### PR TITLE
feat: implemented the 'Proof of Game' via SHA-256 Move History hashing feature while ensuring high resource efficiency (Gas/CPU) by utilizing a Rolling Hash

### DIFF
--- a/contracts/game_contract/src/lib.rs
+++ b/contracts/game_contract/src/lib.rs
@@ -31,6 +31,7 @@ pub struct Game {
     pub moves: Vec<ChessMove>,
     pub created_at: u64,
     pub winner: Option<Address>,
+    pub proof_of_game: BytesN<32>,
 }
 
 #[contracttype]
@@ -151,6 +152,7 @@ impl GameContract {
             moves: Vec::new(&env),
             created_at: env.ledger().sequence() as u64,
             winner: None,
+            proof_of_game: BytesN::from_array(&env, &[0; 32]),
         };
 
         let mut games: Map<u64, Game> = env
@@ -262,10 +264,22 @@ impl GameContract {
 
         let chess_move = ChessMove {
             player: player.clone(),
-            move_data,
+            move_data: move_data.clone(),
             timestamp: env.ledger().sequence() as u64,
         };
-        game.moves.push_back(chess_move.into());
+
+        let mut proof_payload = Bytes::new(&env);
+        proof_payload.append(&game.proof_of_game.clone().into());
+        for m in move_data.iter() {
+            proof_payload.append(&Bytes::from_slice(&env, &m.to_le_bytes()));
+        }
+        proof_payload.append(&Bytes::from_slice(
+            &env,
+            &chess_move.timestamp.to_le_bytes(),
+        ));
+        game.proof_of_game = env.crypto().sha256(&proof_payload).into();
+
+        game.moves.push_back(chess_move);
         game.current_turn = if game.current_turn == 1 { 2 } else { 1 };
 
         games.set(game_id, game);


### PR DESCRIPTION
# Implementation Details:

* Added proof_of_game Field: The Game state struct now tracks an individual proof_of_game field of type BytesN<32>.

* Initial State (Genesis Hash): When a game is successfully created via create_game, the proof_of_game initializes with a zeroed-out memory space BytesN::from_array(&env, &[0; 32]).

* Optimized Move Settlement (O(1) Gas Costs): Instead of iterating through potentially hundreds of stored moves when a game concludes or requires verification, proof_of_game incrementally updates during every submit_move. It creates an env.crypto().sha256(payload) over (previous_proof_hash || move_data || timestamp).

Using an incremental cryptographic chaining strategy completely removes large allocation bottlenecks for huge dynamic arrays, securing standard operation against network limits or elevated CPU fees on Stellar and keeping node operations incredibly lightweight.

The underlying unit tests with the rust compilation were run locally and successfully passed!

Closes #507 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Games now include proof-of-move tracking that updates with each move submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->