### PR TITLE
feat(chess): add responsive mobile board interface

### DIFF
--- a/frontend/app/play/[slug]/page.tsx
+++ b/frontend/app/play/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { FaUser, FaClock, FaSignal } from "react-icons/fa";
 import { Web3StatusBar } from "@/components/Web3StatusBar";
 import { useCheatDetection } from "@/hook/useCheatDetection";
 import { CheatDetectionPanel } from "@/components/chess/CheatDetectionPanel";
+import { useIsMobile } from "@/hook/use-mobile";
 
 const ChessboardComponent = dynamic(
   () => import("@/components/chess/ChessboardComponent"),
@@ -48,6 +49,8 @@ export default function PlayOnlinePage() {
   const [playerColor] = useState<"white" | "black">("white");
   const [gameStatus, setGameStatus] = useState<GameStatus>("playing");
   const [isCheatPanelExpanded, setIsCheatPanelExpanded] = useState(false);
+  const [isMoveHistoryOpen, setIsMoveHistoryOpen] = useState(false);
+  const isMobile = useIsMobile();
 
   const {
     status: socketStatus,
@@ -283,6 +286,31 @@ export default function PlayOnlinePage() {
                 </span>
               </div>
             </div>
+
+            {/* Mobile controls — visible only on mobile, directly below board */}
+            <div className="flex items-center gap-2 mt-3 lg:hidden">
+              <button
+                onClick={() => {}}
+                aria-label="Flip board orientation"
+                className="flex-1 py-2.5 rounded-xl bg-gray-800/60 hover:bg-gray-700/60 border border-gray-700/50 text-gray-300 text-sm font-medium transition-all duration-300"
+              >
+                Flip Board
+              </button>
+              <button
+                onClick={handleResign}
+                disabled={gameStatus !== "playing"}
+                aria-label="Resign game"
+                className="flex-1 py-2.5 rounded-xl bg-red-500/10 hover:bg-red-500/20 border border-red-500/30 text-red-400 text-sm font-medium transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Resign
+              </button>
+              <div className="flex items-center gap-1.5 px-2 shrink-0">
+                <FaSignal className={`text-xs ${socketStatusColor()}`} />
+                <span className={`text-xs ${socketStatusColor()}`}>
+                  {socketStatusLabel()}
+                </span>
+              </div>
+            </div>
           </div>
 
           {/* Game Sidebar - Move History & Controls */}
@@ -293,7 +321,7 @@ export default function PlayOnlinePage() {
                 <h3 className="text-sm font-semibold text-gray-300">
                   Game Status
                 </h3>
-                <div className="flex items-center gap-1.5">
+                <div className="hidden lg:flex items-center gap-1.5">
                   <FaSignal className={`text-xs ${socketStatusColor()}`} />
                   <span className={`text-xs ${socketStatusColor()}`}>
                     {socketStatusLabel()}
@@ -325,10 +353,17 @@ export default function PlayOnlinePage() {
 
             {/* Move History */}
             <div className="rounded-xl border border-gray-700/50 bg-gray-800/40 p-4" role="region" aria-label="Move history">
-              <h3 className="text-sm font-semibold text-gray-300 mb-3">
-                Moves
-              </h3>
-              <div className="max-h-64 overflow-y-auto space-y-0.5">
+              <button
+                className="flex items-center justify-between w-full text-left"
+                onClick={() => isMobile && setIsMoveHistoryOpen((prev) => !prev)}
+                aria-expanded={isMobile ? isMoveHistoryOpen : true}
+              >
+                <h3 className="text-sm font-semibold text-gray-300">Moves</h3>
+                <span className="text-gray-500 text-xs lg:hidden">
+                  {isMoveHistoryOpen ? "▲" : "▼"}
+                </span>
+              </button>
+              <div className={`max-h-64 overflow-y-auto space-y-0.5 mt-3 ${isMobile && !isMoveHistoryOpen ? "hidden" : ""}`}>
                 {movePairs.length === 0 ? (
                   <p className="text-xs text-gray-500 italic">
                     No moves yet.{" "}
@@ -364,8 +399,8 @@ export default function PlayOnlinePage() {
               onToggle={() => setIsCheatPanelExpanded((prev: boolean) => !prev)}
             />
 
-            {/* Controls */}
-            <div className="flex gap-2">
+            {/* Controls — desktop only, mobile controls are above the sidebar */}
+            <div className="hidden lg:flex gap-2">
               <button
                 onClick={() => {}}
                 aria-label="Flip board orientation"

--- a/frontend/components/chess/ChessboardComponent.tsx
+++ b/frontend/components/chess/ChessboardComponent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import Image from "next/image";
 
 import WhiteKing from "./chesspieces/white-king.svg";
@@ -74,6 +74,9 @@ const ChessboardComponent: React.FC<ChessboardComponentProps> = ({
   const [mounted, setMounted] = useState(false);
   const [boardWidth, setBoardWidth] = useState(width || 560);
   const [selectedSquare, setSelectedSquare] = useState<string | null>(null);
+  const [hoveredSquare, setHoveredSquare] = useState<string | null>(null);
+  const touchStartSquare = useRef<string | null>(null);
+  const boardRef = useRef<HTMLDivElement>(null);
 
   // Memoize board state parsing - prevents re-parsing on every render
   const boardState = useMemo(() => parseFen(position), [position]);
@@ -271,6 +274,51 @@ const ChessboardComponent: React.FC<ChessboardComponentProps> = ({
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
   }, []);
+
+  const getSquareFromTouch = useCallback((touch: React.Touch): [number, number] | null => {
+    if (!boardRef.current) return null;
+    const rect = boardRef.current.getBoundingClientRect();
+    const x = touch.clientX - rect.left;
+    const y = touch.clientY - rect.top;
+    const col = Math.floor((x / rect.width) * 8);
+    const row = Math.floor((y / rect.height) * 8);
+    if (col < 0 || col > 7 || row < 0 || row > 7) return null;
+    return [row, col];
+  }, []);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent, row: number, col: number) => {
+      if (!boardState[row][col]) return;
+      touchStartSquare.current = `${row},${col}`;
+      setSelectedSquare(`${row},${col}`);
+    },
+    [boardState],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!touchStartSquare.current) return;
+      const sq = getSquareFromTouch(e.touches[0]);
+      if (sq) setHoveredSquare(`${sq[0]},${sq[1]}`);
+    },
+    [getSquareFromTouch],
+  );
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (!touchStartSquare.current) return;
+      const sq = getSquareFromTouch(e.changedTouches[0]);
+      if (sq) {
+        const [srcRow, srcCol] = touchStartSquare.current.split(",").map(Number);
+        attemptMove(srcRow, srcCol, sq[0], sq[1]);
+      }
+      touchStartSquare.current = null;
+      setHoveredSquare(null);
+      setSelectedSquare(null);
+    },
+    [getSquareFromTouch, attemptMove],
+  );
+
   if (!mounted) {
     return (
       <div className="w-full h-full flex items-center justify-center bg-gray-800 rounded-md">
@@ -280,9 +328,12 @@ const ChessboardComponent: React.FC<ChessboardComponentProps> = ({
   }
   return (
     <div
+      ref={boardRef}
       className="chessboard-container w-full mx-auto relative"
       role="grid"
       aria-label="Chess Board"
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
       style={{
         width: "100%",
         maxWidth: `${boardWidth}px`,
@@ -306,7 +357,9 @@ const ChessboardComponent: React.FC<ChessboardComponentProps> = ({
       {boardState.map((row, rowIndex) =>
         row.map((piece, colIndex) => {
           const isLight = (rowIndex + colIndex) % 2 === 1;
-          const isSelected = selectedSquare === `${rowIndex},${colIndex}`;
+          const squareKey = `${rowIndex},${colIndex}`;
+          const isSelected = selectedSquare === squareKey;
+          const isHovered = hoveredSquare === squareKey && hoveredSquare !== selectedSquare;
           return (
             <div
               key={`${rowIndex}-${colIndex}`}
@@ -331,10 +384,13 @@ const ChessboardComponent: React.FC<ChessboardComponentProps> = ({
                 position: "relative",
                 boxShadow: isSelected
                   ? "inset 0 0 0 3px rgba(0, 93, 173, 0.75)"
+                  : isHovered
+                  ? "inset 0 0 0 3px rgba(0, 200, 170, 0.7)"
                   : "none",
-                transition: "background-color 0.2s ease",
+                transition: "background-color 0.2s ease, box-shadow 0.1s ease",
               }}
               onClick={() => handleSquareClick(rowIndex, colIndex)}
+              onTouchStart={(e) => handleTouchStart(e, rowIndex, colIndex)}
               draggable={!!piece}
               onDragStart={(e) => handleDragStart(e, rowIndex, colIndex)}
               onDragEnd={handleDragEnd}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8390,7 +8390,6 @@
       "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.5",
         "@asamuzakjp/dom-selector": "^7.0.6",


### PR DESCRIPTION
## Summary
Enhances the play page and chessboard component for mobile UX.

## Changes

### `components/chess/ChessboardComponent.tsx`
- Added `boardRef` to compute square coordinates from touch position
- Added `touchStartSquare` ref to track lifted piece
- Added `hoveredSquare` state — renders teal inset ring on target square during drag
- Wired `onTouchStart` per square, `onTouchMove`/`onTouchEnd` on board container

### `app/play/[slug]/page.tsx`
- Added mobile action row (`lg:hidden`) directly below board — exposes Flip, Resign, and connection status without scrolling
- Desktop controls (`hidden lg:flex`) unchanged for ≥1024px
- Move history header is now a toggle button on mobile (`isMoveHistoryOpen` state)
- Socket status indicator hidden from Game Status card on mobile (shown in action row instead)

## Testing
- Desktop: no visual change, sidebar controls intact
- Mobile (< 1024px): action row visible below board, move history collapsible
- Touch drag: tap piece → drag → teal highlight tracks finger → release to move

Close #580 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added touch-based piece movement on mobile devices with visual hover feedback and smooth animations
  * Introduced collapsible move history panel optimized for mobile layouts
  * New mobile control bar featuring resign, flip board, and connection status indicator
  * Enhanced responsive design with mobile and desktop-specific UI elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->