### PR TITLE
fix: improve frontend accessibility roles

### DIFF
--- a/frontend/__tests__/AiPersonalityModal.test.tsx
+++ b/frontend/__tests__/AiPersonalityModal.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AiPersonalityModal } from "@/app/components/matchmaking/AiPersonalityModal";
+
+const setAiPersonality = vi.fn();
+
+vi.mock("@/context/matchmakingContext", () => ({
+  useMatchmakingContext: () => ({
+    aiPersonality: "defensive",
+    setAiPersonality,
+    chessVariant: "standard",
+  }),
+}));
+
+vi.mock("@/lib/chessVariants", () => ({
+  getChessVariantById: () => ({
+    label: "Standard",
+    description: "Classic chess rules.",
+    averageGameTime: "10 min",
+  }),
+}));
+
+describe("AiPersonalityModal accessibility", () => {
+  beforeEach(() => {
+    setAiPersonality.mockClear();
+  });
+
+  it("renders a labelled modal dialog with descriptive copy", () => {
+    render(
+      <AiPersonalityModal
+        isOpen
+        onClose={() => undefined}
+        onConfirm={() => undefined}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Finalize Match Setup" });
+
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleDescription(
+      "Lock in your preferred chess format and AI co-pilot before matchmaking starts.",
+    );
+  });
+
+  it("exposes personality choices as pressed buttons", () => {
+    render(
+      <AiPersonalityModal
+        isOpen
+        onClose={() => undefined}
+        onConfirm={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /^select defensive/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /^select aggressive/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^select sacrificial/i }));
+
+    expect(setAiPersonality).toHaveBeenCalledWith("sacrificial");
+  });
+
+  it("closes with the Escape key", () => {
+    const onClose = vi.fn();
+
+    render(
+      <AiPersonalityModal
+        isOpen
+        onClose={onClose}
+        onConfirm={() => undefined}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/components/matchmaking/AiPersonalityModal.tsx
+++ b/frontend/app/components/matchmaking/AiPersonalityModal.tsx
@@ -107,20 +107,46 @@ export function AiPersonalityModal({
     useMatchmakingContext();
   const selectedVariant = getChessVariantById(chessVariant);
 
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ai-personality-modal-title"
+      aria-describedby="ai-personality-modal-description"
+    >
       {/* Backdrop */}
       <div
         className="fixed inset-0 bg-black/70 backdrop-blur-sm"
         onClick={onClose}
+        aria-hidden="true"
       />
 
       {/* Modal panel */}
       <div className="relative z-10 w-full max-w-lg mx-4 bg-gray-900 rounded-2xl border border-gray-700 shadow-2xl p-6 space-y-6">
         {/* Close button */}
         <button
+          type="button"
           onClick={onClose}
           className="absolute top-4 right-4 text-gray-400 hover:text-white transition-colors duration-200"
           aria-label="Close personality selector"
@@ -143,10 +169,10 @@ export function AiPersonalityModal({
 
         {/* Header */}
         <div className="text-center space-y-1">
-          <h2 className="text-2xl font-bold text-white tracking-wide">
+          <h2 id="ai-personality-modal-title" className="text-2xl font-bold text-white tracking-wide">
             Finalize Match Setup
           </h2>
-          <p className="text-gray-400 text-sm">
+          <p id="ai-personality-modal-description" className="text-gray-400 text-sm">
             Lock in your preferred chess format and AI co-pilot before matchmaking starts.
           </p>
         </div>
@@ -171,13 +197,16 @@ export function AiPersonalityModal({
         </div>
 
         {/* Personality cards */}
-        <div className="space-y-3">
+        <div className="space-y-3" role="group" aria-label="AI personality options">
           {PERSONALITIES.map((option) => {
             const isSelected = aiPersonality === option.id;
             return (
               <button
+                type="button"
                 key={option.id}
                 onClick={() => setAiPersonality(option.id)}
+                aria-pressed={isSelected}
+                aria-label={`Select ${option.label} AI personality. ${option.description}`}
                 className={`personality-card w-full flex items-center gap-4 p-4 rounded-xl border-2 text-left transition-all duration-250
                   ${
                     isSelected
@@ -198,6 +227,7 @@ export function AiPersonalityModal({
                 </div>
                 {/* Selection indicator */}
                 <div
+                  aria-hidden="true"
                   className={`flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all duration-200
                     ${isSelected ? `${option.borderColor} bg-transparent` : "border-gray-600"}`}
                 >
@@ -212,6 +242,7 @@ export function AiPersonalityModal({
 
         {/* Confirm button */}
         <button
+          type="button"
           onClick={onConfirm}
           className="confirm-btn w-full py-3 rounded-xl font-bold text-white text-sm uppercase tracking-widest bg-gradient-to-r from-teal-500 to-blue-700 hover:from-teal-600 hover:to-blue-800 transition-all duration-300 hover:scale-[1.02] active:scale-[0.98]"
         >

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,7 +9,7 @@ import { ThemeProvider } from "next-themes";
 
 export const metadata: Metadata = {
   title: "XLMate",
-  description: "XLMate — Chess on Stellar",
+  description: "XLMate - Chess on Stellar",
 };
 
 export default function RootLayout({

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -73,7 +73,7 @@ export default function Home() {
     [gameId, socketSendMove, matchmakingSendMove],
   );
 
-  // Kick off matchmaking when online mode is selected — but only after personality is confirmed
+  // Kick off matchmaking when online mode is selected, but only after personality is confirmed.
   // (joinMatchmaking is now called from handlePersonalityConfirm, not here)
 
   useEffect(() => {
@@ -122,7 +122,7 @@ export default function Home() {
       });
       if (move) setPosition(game.fen());
     } catch {
-      // illegal move from server — ignore
+      // Illegal move from server; ignore it and wait for the next valid update.
     }
   }, [lastOpponentMove, game]);
 
@@ -194,12 +194,12 @@ export default function Home() {
 
   // Searching / waiting overlay label
   const onlineStatusLabel = () => {
-    if (socketStatus === "reconnecting") return "🔄 Reconnecting...";
-    if (matchmakingStatus === "match_found") return "✅ Match found! Starting…";
+    if (socketStatus === "reconnecting") return "Reconnecting...";
+    if (matchmakingStatus === "match_found") return "Match found! Starting...";
     if (socketStatus === "connected")
-      return `🟢 Online Match (you are ${playerColor})`;
+      return `Online Match (you are ${playerColor})`;
     if (matchmakingStatus === "error" || socketStatus === "error")
-      return `❌ ${matchmakingError ?? "Connection error"}`;
+      return matchmakingError ?? "Connection error";
     return "Online Match";
   };
 
@@ -249,10 +249,10 @@ export default function Home() {
             )}
 
             {gameMode === "online" && matchmakingStatus === "searching" && (
-              <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center animate-overlay-in" role="dialog" aria-modal="true" aria-label="Searching for opponent">
+              <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center animate-overlay-in" role="dialog" aria-modal="true" aria-labelledby="searching-opponent-title" aria-describedby="searching-opponent-description">
                 <div className="bg-gray-900 p-8 rounded-2xl border border-yellow-500/30 text-center animate-modal-in max-w-sm w-full mx-4">
                   <div className="flex flex-col items-center gap-4">
-                    <h3 className="text-xl font-bold text-yellow-400">
+                    <h3 id="searching-opponent-title" className="text-xl font-bold text-yellow-400">
                       Looking for opponent...
                     </h3>
                     <span className="relative flex h-10 w-10">
@@ -260,8 +260,8 @@ export default function Home() {
                       <span className="relative inline-flex rounded-full h-10 w-10 border-2 border-yellow-500 bg-yellow-500/10"></span>
                     </span>
 
-                    <p className="text-gray-300 text-sm" aria-live="polite">
-                      {onlinePlayerCount} Players online
+                    <p id="searching-opponent-description" className="text-gray-300 text-sm" aria-live="polite">
+                      {onlinePlayerCount ?? "Unknown"} players online
                     </p>
                     <p className="text-cyan-100 text-xs uppercase tracking-[0.24em]">
                       Queueing for {selectedVariant.label}
@@ -279,14 +279,14 @@ export default function Home() {
             )}
 
             {gameMode === "online" && socketStatus === "reconnecting" && (
-              <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center animate-overlay-in" role="dialog" aria-modal="true" aria-label="Reconnecting to game">
+              <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center animate-overlay-in" role="dialog" aria-modal="true" aria-labelledby="reconnecting-game-title" aria-describedby="reconnecting-game-description">
                 <div className="bg-gray-900 p-8 rounded-2xl border border-yellow-500/30 text-center animate-modal-in max-w-sm w-full mx-4">
                   <div className="flex flex-col items-center gap-4">
                     <div className="w-10 h-10 rounded-full border-2 border-yellow-500 border-t-transparent animate-spin" />
-                    <h3 className="text-xl font-bold text-yellow-400">
+                    <h3 id="reconnecting-game-title" className="text-xl font-bold text-yellow-400">
                       Reconnecting...
                     </h3>
-                    <p className="text-gray-300 text-sm">
+                    <p id="reconnecting-game-description" className="text-gray-300 text-sm">
                       Attempting to restore connection
                     </p>
                     <button

--- a/frontend/app/puzzles/page.tsx
+++ b/frontend/app/puzzles/page.tsx
@@ -180,7 +180,7 @@ export default function PuzzlesPage() {
     setIsClaiming(true);
 
     const result = await executeClaim(async () => {
-      // Simulate on-chain reward claim — in production this would invoke a Soroban contract
+      // Simulate on-chain reward claim; production would invoke a Soroban contract.
       await new Promise((resolve) => setTimeout(resolve, 1500));
       return true;
     });
@@ -240,21 +240,22 @@ export default function PuzzlesPage() {
       <div className="min-h-screen p-4 md:p-8" role="region" aria-label="Chess Puzzles">
         {/* Reward Popup */}
         {showReward && (
-          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center animate-overlay-in" role="dialog" aria-modal="true" aria-label="Puzzle reward">
+          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center animate-overlay-in" role="dialog" aria-modal="true" aria-labelledby="puzzle-reward-title" aria-describedby="puzzle-reward-description">
             <div className="bg-gray-900 p-8 rounded-2xl border border-emerald-500/30 text-center animate-modal-in max-w-sm w-full mx-4">
               <div className="flex flex-col items-center gap-4">
                 <div className="w-16 h-16 rounded-full bg-gradient-to-br from-yellow-400/20 to-emerald-500/20 flex items-center justify-center">
                   <FaTrophy className="text-4xl text-yellow-400" />
                 </div>
-                <h3 className="text-2xl font-bold text-emerald-400">Puzzle Complete!</h3>
-                <p className="text-xl text-white">+{rewardAmount} XLM</p>
-                <div className="text-sm text-gray-400 space-y-1">
-                  <p>✅ Backend verification complete</p>
-                  <p>🎁 Reward ready to claim</p>
+                <h3 id="puzzle-reward-title" className="text-2xl font-bold text-emerald-400">Puzzle Complete!</h3>
+                <p id="puzzle-reward-description" className="text-xl text-white">+{rewardAmount} XLM reward ready to claim</p>
+                <div className="text-sm text-gray-400 space-y-1" aria-label="Reward claim status">
+                  <p>Backend verification complete</p>
+                  <p>Reward ready to claim</p>
                 </div>
                 <button
                   onClick={handleClaimReward}
                   disabled={isClaiming}
+                  aria-busy={isClaiming}
                   className="w-full py-3 rounded-xl bg-gradient-to-r from-emerald-500 to-teal-600 hover:from-emerald-600 hover:to-teal-700 disabled:opacity-50 text-white font-bold text-sm transition-all duration-300 hover:scale-[1.02] active:scale-[0.98]"
                 >
                   {isClaiming ? (
@@ -334,6 +335,7 @@ export default function PuzzlesPage() {
                   <button
                     onClick={handleMoveBack}
                     disabled={currentMove === 0}
+                    aria-label="Go back one puzzle move"
                     className="flex-1 px-4 py-2.5 bg-gray-700/60 hover:bg-gray-600/60 disabled:bg-gray-800/40 disabled:text-gray-600 rounded-xl text-white font-medium transition-colors text-sm"
                   >
                     <FaTimes className="inline mr-2" />
@@ -341,6 +343,7 @@ export default function PuzzlesPage() {
                   </button>
                   <button
                     onClick={handleReset}
+                    aria-label="Reset current puzzle"
                     className="flex-1 px-4 py-2.5 bg-gray-700/60 hover:bg-gray-600/60 rounded-xl text-white font-medium transition-colors text-sm"
                   >
                     <FaRedo className="inline mr-2" />
@@ -350,9 +353,10 @@ export default function PuzzlesPage() {
                 <button
                   onClick={() => setShowHint(!showHint)}
                   aria-pressed={showHint}
+                  aria-controls={selectedPuzzle.hint ? "puzzle-hint" : undefined}
                   className="w-full px-4 py-2.5 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/30 rounded-xl text-blue-400 font-medium transition-colors text-sm"
                 >
-                  💡 Hint
+                  Hint
                 </button>
                 <button
                   onClick={handleMoveNext}
@@ -364,16 +368,16 @@ export default function PuzzlesPage() {
                       Submit Solution
                     </>
                   ) : (
-                    "Next Move →"
+                    "Next Move"
                   )}
                 </button>
               </div>
           
               {/* Hint Display */}
               {showHint && selectedPuzzle.hint && (
-                <div className="mt-3 p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg animate-scale-in">
+                <div id="puzzle-hint" className="mt-3 p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg animate-scale-in">
                   <p className="text-blue-400 text-sm">
-                    💡 {selectedPuzzle.hint}
+                    {selectedPuzzle.hint}
                   </p>
                 </div>
               )}
@@ -390,7 +394,7 @@ export default function PuzzlesPage() {
                   aria-live="assertive"
                 >
                   <p className="font-medium text-sm">
-                    {isCorrect ? '✅ Correct! Well done!' : '❌ Not quite right. Try again!'}
+                    {isCorrect ? 'Correct! Well done!' : 'Not quite right. Try again!'}
                   </p>
                 </div>
               )}
@@ -436,19 +440,17 @@ export default function PuzzlesPage() {
           {MOCK_PUZZLES.map((puzzle, idx) => {
             const isCompleted = completedPuzzles.has(puzzle.id);
             return (
-              <div
+              <button
+                type="button"
                 key={puzzle.id}
-                className={`bg-gray-800/60 p-6 rounded-xl border transition-all duration-300 hover:scale-[1.03] cursor-pointer animate-slide-up ${
+                className={`w-full bg-gray-800/60 p-6 rounded-xl border text-left transition-all duration-300 hover:scale-[1.03] cursor-pointer animate-slide-up focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-300 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 ${
                   isCompleted 
                     ? 'border-emerald-500/30 bg-emerald-500/5' 
                     : 'border-gray-700/50 hover:border-gray-600/50'
                 }`}
                 style={{ animationDelay: `${idx * 0.05}s` }}
                 onClick={() => handlePuzzleSelect(puzzle)}
-                onKeyDown={(e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handlePuzzleSelect(puzzle); } }}
-                role="button"
-                tabIndex={0}
-                aria-label={`${puzzle.title} — ${puzzle.difficulty} difficulty${isCompleted ? ', completed' : ''}`}
+                aria-label={`${puzzle.title}, ${puzzle.difficulty} difficulty${isCompleted ? ', completed' : ''}`}
               >
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="text-lg font-bold text-white">{puzzle.title}</h3>
@@ -466,7 +468,7 @@ export default function PuzzlesPage() {
                   <span className="text-xs text-gray-500">Puzzle #{puzzle.id}</span>
                   <span className="text-xs text-emerald-400 font-medium">+0.01 XLM</span>
                 </div>
-              </div>
+              </button>
             );
           })}
         </div>

--- a/frontend/components/GameModeButtons.tsx
+++ b/frontend/components/GameModeButtons.tsx
@@ -34,10 +34,10 @@ const GameModeButtons: React.FC<GameModeButtonsProps> = ({ setGameMode }) => {
       <div className="play-button-container relative">
         <button
           onClick={() => setGameMode("online")}
-          aria-label="Play Online — Play with someone at your level"
+          aria-label="Play Online. Play with someone at your level"
           className="play-button w-full p-4 relative border-none outline-none cursor-pointer transition-all duration-300 ease-in-out z-[2] overflow-hidden flex items-center justify-center bg-transparent"
         >
-          <span className="button-text flex items-center gap-6 z-[3]">
+          <div className="button-text flex items-center gap-6 z-[3]">
             <div className="bg-teal-400/20 p-3 rounded-full shadow-lg">
               <FaUser className="text-3xl text-white filter drop-shadow-md" />
             </div>
@@ -49,7 +49,7 @@ const GameModeButtons: React.FC<GameModeButtonsProps> = ({ setGameMode }) => {
                 Play with someone at your level
               </p>
             </div>
-          </span>
+          </div>
           <div className="clip absolute inset-0 border-[5px] border-solid border-transparent bg-gradient-to-r from-teal-500 to-blue-700 transition-all duration-300 ease-in-out" />
           <div className="corner top-left absolute w-[30px] h-[30px] bg-teal-500" />
           <div className="corner top-right absolute w-[30px] h-[30px] bg-blue-700" />
@@ -61,10 +61,10 @@ const GameModeButtons: React.FC<GameModeButtonsProps> = ({ setGameMode }) => {
       <div className="play-button-container relative">
         <button
           onClick={() => setGameMode("bot")}
-          aria-label="Play Bots — Play vs customizable training bots"
+          aria-label="Play Bots. Play vs customizable training bots"
           className="play-button w-full p-4 relative border-none outline-none cursor-pointer transition-all duration-300 ease-in-out z-[2] overflow-hidden flex items-center justify-center bg-transparent"
         >
-          <span className="button-text flex items-center gap-6 z-[3]">
+          <div className="button-text flex items-center gap-6 z-[3]">
             <div className="bg-[#008e90]/20 p-3 rounded-full shadow-lg">
               <RiAliensFill className="text-3xl text-white filter drop-shadow-md" />
             </div>
@@ -74,7 +74,7 @@ const GameModeButtons: React.FC<GameModeButtonsProps> = ({ setGameMode }) => {
                 Play vs customizable training bots
               </p>
             </div>
-          </span>
+          </div>
           <div className="clip absolute inset-0 border-[5px] border-solid border-transparent bg-[#008e90] transition-all duration-300 ease-in-out" />
           <div className="corner top-left absolute w-[30px] h-[30px] bg-[#008e90]" />
           <div className="corner top-right absolute w-[30px] h-[30px] bg-[#008e90]" />
@@ -86,10 +86,10 @@ const GameModeButtons: React.FC<GameModeButtonsProps> = ({ setGameMode }) => {
       <div className="play-button-container relative">
         <button
           onClick={() => router.push("/puzzles")}
-          aria-label="Learn and Earn — Solve puzzles to earn XLM rewards"
+          aria-label="Learn and Earn. Solve puzzles to earn XLM rewards"
           className="play-button w-full p-4 relative border-none outline-none cursor-pointer transition-all duration-300 ease-in-out z-[2] overflow-hidden flex items-center justify-center bg-transparent"
         >
-          <span className="button-text flex items-center gap-6 z-[3]">
+          <div className="button-text flex items-center gap-6 z-[3]">
             <div className="bg-yellow-400/20 p-3 rounded-full shadow-lg">
               <FaTrophy className="text-3xl text-white filter drop-shadow-md" />
             </div>
@@ -101,7 +101,7 @@ const GameModeButtons: React.FC<GameModeButtonsProps> = ({ setGameMode }) => {
                 Solve puzzles to earn XLM rewards
               </p>
             </div>
-          </span>
+          </div>
           <div className="clip absolute inset-0 border-[5px] border-solid border-transparent bg-gradient-to-r from-yellow-500 to-orange-600 transition-all duration-300 ease-in-out" />
           <div className="corner top-left absolute w-[30px] h-[30px] bg-yellow-500" />
           <div className="corner top-right absolute w-[30px] h-[30px] bg-orange-600" />

--- a/frontend/types/react-icons.d.ts
+++ b/frontend/types/react-icons.d.ts
@@ -1,0 +1,44 @@
+declare module "react-icons/fa" {
+  import type { ComponentType, SVGProps } from "react";
+
+  export type IconType = ComponentType<SVGProps<SVGSVGElement>>;
+
+  export const FaBolt: IconType;
+  export const FaArrowLeft: IconType;
+  export const FaBrain: IconType;
+  export const FaCheck: IconType;
+  export const FaChartLine: IconType;
+  export const FaCheckCircle: IconType;
+  export const FaChess: IconType;
+  export const FaChessBoard: IconType;
+  export const FaClock: IconType;
+  export const FaCrown: IconType;
+  export const FaExclamationTriangle: IconType;
+  export const FaEye: IconType;
+  export const FaFire: IconType;
+  export const FaGamepad: IconType;
+  export const FaHistory: IconType;
+  export const FaPlay: IconType;
+  export const FaRedo: IconType;
+  export const FaRobot: IconType;
+  export const FaSearch: IconType;
+  export const FaShieldAlt: IconType;
+  export const FaSignal: IconType;
+  export const FaSpinner: IconType;
+  export const FaStar: IconType;
+  export const FaTimes: IconType;
+  export const FaTrophy: IconType;
+  export const FaUser: IconType;
+  export const FaUsers: IconType;
+  export const FaWallet: IconType;
+}
+
+declare module "react-icons/ri" {
+  import type { ComponentType, SVGProps } from "react";
+
+  export type IconType = ComponentType<SVGProps<SVGSVGElement>>;
+
+  export const RiAiGenerate: IconType;
+  export const RiAliensFill: IconType;
+  export const RiRobot2Line: IconType;
+}


### PR DESCRIPTION
Closes #589

---

## Summary

Addresses #589 by improving frontend accessibility semantics and ARIA coverage across key app flows.

- Adds labelled `dialog` semantics to matchmaking, searching, reconnecting, and puzzle reward modals
- Adds Escape-key close support for the AI personality modal
- Marks AI personality choices with `aria-pressed` and descriptive accessible names
- Converts puzzle cards from clickable `div role="button"` elements to native buttons
- Cleans status/reward text so screen readers announce readable content
- Fixes invalid nested content inside game mode buttons
- Adds local `react-icons` type declarations so frontend typechecks cleanly

## Tests

- Added ARIA-focused tests for `AiPersonalityModal`
- `npx tsc --noEmit --pretty false` passes

